### PR TITLE
Fix step.md

### DIFF
--- a/microservice-vulns/psa-baseline/step1/step.md
+++ b/microservice-vulns/psa-baseline/step1/step.md
@@ -36,7 +36,7 @@ spec:
   - name: test
     image: nginx
     securityContext:
-      runAsNonRoot: false
+      privileged: true
 EOF
 ```{{EXEC}}
 


### PR DESCRIPTION
`runAsNonRoot: false` is allowed in the `baseline` level: https://kubernetes.io/docs/concepts/security/pod-security-standards/

It's not allowed on the `restricted` level only